### PR TITLE
feat: Configure TypeScript for strict type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrl = process.env['NEXT_PUBLIC_SUPABASE_URL']
+const supabaseAnonKey = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing Supabase environment variables')

--- a/src/test/css-variables.test.ts
+++ b/src/test/css-variables.test.ts
@@ -117,7 +117,7 @@ describe('CSS Variables Validation', () => {
 
   describe('Base Styles', () => {
     it('should set html font-size to 16px for rem calculations', () => {
-      expect(cssContent).toMatch(/html\s*{\s*font-size:\s*16px;.*?}/s)
+      expect(cssContent).toMatch(/html\s*{\s*font-size:\s*16px;[^}]*}/)
     })
 
     it('should apply correct body styles', () => {

--- a/src/test/supabase.test.ts
+++ b/src/test/supabase.test.ts
@@ -19,8 +19,8 @@ describe('Supabase Configuration', () => {
 
   it('should create a Supabase client with environment variables', async () => {
     // Set environment variables
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
+    process.env['NEXT_PUBLIC_SUPABASE_URL'] = 'https://test.supabase.co'
+    process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'] = 'test-anon-key'
 
     // Import the module (this will trigger the client creation)
     const { supabase } = await import('../lib/supabase')
@@ -38,8 +38,8 @@ describe('Supabase Configuration', () => {
 
   it('should throw an error if environment variables are missing', async () => {
     // Clear environment variables
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL
-    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    delete process.env['NEXT_PUBLIC_SUPABASE_URL']
+    delete process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']
 
     // Attempt to import should throw an error
     await expect(async () => {
@@ -49,8 +49,8 @@ describe('Supabase Configuration', () => {
 
   it('should throw an error if only URL is missing', async () => {
     // Set only one environment variable
-    delete process.env.NEXT_PUBLIC_SUPABASE_URL
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key'
+    delete process.env['NEXT_PUBLIC_SUPABASE_URL']
+    process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'] = 'test-anon-key'
 
     await expect(async () => {
       await import('../lib/supabase')
@@ -59,8 +59,8 @@ describe('Supabase Configuration', () => {
 
   it('should throw an error if only anon key is missing', async () => {
     // Set only one environment variable
-    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
-    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env['NEXT_PUBLIC_SUPABASE_URL'] = 'https://test.supabase.co'
+    delete process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']
 
     await expect(async () => {
       await import('../lib/supabase')

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,71 @@
+export interface Database {
+  public: {
+    Tables: {
+      users: {
+        Row: {
+          id: string;
+          email: string;
+          name: string | null;
+          avatar_url: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          email: string;
+          name?: string | null;
+          avatar_url?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          email?: string;
+          name?: string | null;
+          avatar_url?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+}
+
+export type Tables<T extends keyof Database['public']['Tables']> = Database['public']['Tables'][T]['Row'];
+export type Insertable<T extends keyof Database['public']['Tables']> = Database['public']['Tables'][T]['Insert'];
+export type Updatable<T extends keyof Database['public']['Tables']> = Database['public']['Tables'][T]['Update'];
+
+export type DbResult<T> = T extends PromiseLike<infer U> ? U : never;
+export type DbResultOk<T> = T extends PromiseLike<{ data: infer U }> ? Exclude<U, null> : never;
+export type DbResultErr = { error: Error };
+
+export interface QueryOptions {
+  limit?: number;
+  offset?: number;
+  orderBy?: string;
+  ascending?: boolean;
+}
+
+export interface FilterOptions<T = unknown> {
+  eq?: Partial<T>;
+  neq?: Partial<T>;
+  gt?: Partial<T>;
+  gte?: Partial<T>;
+  lt?: Partial<T>;
+  lte?: Partial<T>;
+  like?: Partial<Record<keyof T, string>>;
+  ilike?: Partial<Record<keyof T, string>>;
+  in?: Partial<Record<keyof T, unknown[]>>;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,56 @@
+export interface BaseEntity {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface User extends BaseEntity {
+  email: string;
+  name?: string;
+  avatarUrl?: string;
+}
+
+export interface ApiResponse<T> {
+  data?: T;
+  error?: {
+    message: string;
+    code?: string;
+  };
+  success: boolean;
+}
+
+export interface PaginationParams {
+  page: number;
+  limit: number;
+  sortBy?: string;
+  sortOrder?: 'asc' | 'desc';
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+export type Nullable<T> = T | null;
+export type Optional<T> = T | undefined;
+export type Maybe<T> = T | null | undefined;
+
+export interface ErrorBoundaryState {
+  hasError: boolean;
+  error?: Error;
+}
+
+export interface LoadingState<T> {
+  data?: T;
+  isLoading: boolean;
+  error?: Error;
+}
+
+export type AsyncState<T> = 
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: T }
+  | { status: 'error'; error: Error };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,23 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
@@ -19,7 +32,14 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/app/*": ["./src/app/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/lib/*": ["./src/lib/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/styles/*": ["./src/styles/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- Configured TypeScript with comprehensive strict mode settings
- Created base type definitions for common patterns
- Added path aliases for cleaner imports

Closes #4

## Changes Made
- Updated `tsconfig.json` with all strict mode flags enabled
- Added path aliases for `@/types`, `@/app`, `@/components`, etc.
- Created `src/types/index.ts` with shared type definitions
- Created `src/types/database.ts` with database-related types
- Added `type-check` script to package.json
- Fixed TypeScript errors in existing code to comply with strict mode

## Test Plan
- [x] Run `npm run type-check` - all checks pass
- [x] Run `npm test` - all tests pass
- [x] Run `npm run lint` - no linting errors
- [x] Verify path aliases work correctly in IDE

🤖 Generated with [Claude Code](https://claude.ai/code)