### PR TITLE
fix: resolve sign-out button not working issue

### DIFF
--- a/src/components/auth/SignOutButton.tsx
+++ b/src/components/auth/SignOutButton.tsx
@@ -1,21 +1,44 @@
 'use client';
 
+import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/Button';
 import { useRouter } from 'next/navigation';
 
 export default function SignOutButton() {
+  const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
 
   const handleSignOut = async () => {
+    if (isLoading) return; // Prevent multiple clicks
+
+    setIsLoading(true);
     try {
       const supabase = createClient();
-      await supabase.auth.signOut();
+      const { error } = await supabase.auth.signOut();
+
+      if (error) {
+        console.error('Error signing out:', error);
+      }
+
+      // Always redirect and refresh to update server components
       router.push('/');
+      router.refresh(); // This is crucial for updating server-rendered auth state
     } catch (error) {
       console.error('Error signing out:', error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
-  return <Button onClick={handleSignOut}>Sign Out</Button>;
+  return (
+    <Button
+      onClick={handleSignOut}
+      disabled={isLoading}
+      variant="secondary"
+      size="small"
+    >
+      {isLoading ? 'Signing out...' : 'Sign Out'}
+    </Button>
+  );
 }

--- a/src/components/auth/__tests__/SignOutButton.test.tsx
+++ b/src/components/auth/__tests__/SignOutButton.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useRouter } from 'next/navigation';
 import SignOutButton from '../SignOutButton';
 import { createClient } from '@/lib/supabase/client';
@@ -14,15 +15,16 @@ vi.mock('@/lib/supabase/client', () => ({
 
 describe('SignOutButton', () => {
   const mockPush = vi.fn();
+  const mockRefresh = vi.fn();
   const mockSignOut = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useRouter).mockReturnValue({
       push: mockPush,
+      refresh: mockRefresh,
       back: vi.fn(),
       forward: vi.fn(),
-      refresh: vi.fn(),
       replace: vi.fn(),
       prefetch: vi.fn(),
     } as ReturnType<typeof useRouter>);
@@ -40,46 +42,116 @@ describe('SignOutButton', () => {
   });
 
   it('should handle successful sign out', async () => {
+    const user = userEvent.setup();
     mockSignOut.mockResolvedValue({ error: null });
 
     render(<SignOutButton />);
 
     const signOutButton = screen.getByText('Sign Out');
-    fireEvent.click(signOutButton);
+    await user.click(signOutButton);
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockRefresh).toHaveBeenCalled(); // Verify refresh is called
     });
   });
 
-  it('should handle sign out error gracefully', async () => {
-    mockSignOut.mockResolvedValue({ error: { message: 'Sign out failed' } });
+  it('should display loading state during sign out', async () => {
+    const user = userEvent.setup();
+    mockSignOut.mockImplementation(() => new Promise(() => {})); // Never resolves
 
     render(<SignOutButton />);
 
     const signOutButton = screen.getByText('Sign Out');
-    fireEvent.click(signOutButton);
+    await user.click(signOutButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Signing out...')).toBeInTheDocument();
+      expect(signOutButton).toBeDisabled();
+    });
+  });
+
+  it('should handle sign out error but still redirect', async () => {
+    const user = userEvent.setup();
+    mockSignOut.mockResolvedValue({ error: { message: 'Sign out failed' } });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<SignOutButton />);
+
+    const signOutButton = screen.getByText('Sign Out');
+    await user.click(signOutButton);
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled();
-      // Even with error, it should still redirect
+      expect(consoleSpy).toHaveBeenCalledWith('Error signing out:', {
+        message: 'Sign out failed',
+      });
+      // Should still redirect and refresh even with error
       expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockRefresh).toHaveBeenCalled();
     });
+
+    consoleSpy.mockRestore();
   });
 
   it('should handle network error during sign out', async () => {
-    mockSignOut.mockRejectedValue(new Error('Network error'));
+    const user = userEvent.setup();
+    const error = new Error('Network error');
+    mockSignOut.mockRejectedValue(error);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     render(<SignOutButton />);
 
     const signOutButton = screen.getByText('Sign Out');
-    fireEvent.click(signOutButton);
+    await user.click(signOutButton);
 
     await waitFor(() => {
       expect(mockSignOut).toHaveBeenCalled();
+      expect(consoleSpy).toHaveBeenCalledWith('Error signing out:', error);
       // Should not redirect on network error
       expect(mockPush).not.toHaveBeenCalled();
+      expect(mockRefresh).not.toHaveBeenCalled();
     });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should prevent multiple clicks while signing out', async () => {
+    const user = userEvent.setup();
+    mockSignOut.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ error: null }), 100)
+        )
+    );
+
+    render(<SignOutButton />);
+
+    const signOutButton = screen.getByText('Sign Out');
+
+    // Click multiple times rapidly
+    await user.click(signOutButton);
+    await user.click(signOutButton);
+    await user.click(signOutButton);
+
+    // Should only call signOut once
+    expect(mockSignOut).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockRefresh).toHaveBeenCalled();
+    });
+  });
+
+  it('should have correct button styling', () => {
+    render(<SignOutButton />);
+
+    const signOutButton = screen.getByRole('button', { name: 'Sign Out' });
+    expect(signOutButton).toHaveClass(
+      'inline-flex',
+      'items-center',
+      'justify-center'
+    );
   });
 });


### PR DESCRIPTION
## Summary
Fixed the sign-out button that was not working when clicked. The issue was that server components weren't updating after client-side sign out.

## Root Cause
After signing out on the client side, the server-rendered Header component wasn't re-rendering to reflect the updated authentication state. This caused the UI to remain in a signed-in state even after the user had signed out.

## Changes Made
- Added `router.refresh()` after successful sign out to force server components to re-render
- Implemented loading state with "Signing out..." text to prevent multiple rapid clicks
- Enhanced error handling to still redirect and refresh even when sign-out errors occur
- Added comprehensive test coverage for all new functionality

## Test Plan
- [x] Sign-out button successfully logs user out
- [x] UI updates to show signed-out state after clicking sign out
- [x] Loading state prevents multiple sign-out requests
- [x] Errors during sign-out are handled gracefully
- [x] All unit tests pass

## How to Test
1. Sign in to the application
2. Click the "Sign Out" button in the header
3. Verify that:
   - The button shows "Signing out..." during the process
   - The page redirects to home
   - The header updates to show sign-in/sign-up options
   - You are actually signed out (try accessing a protected route)

Fixes the reported issue where clicking sign out button did nothing.

🤖 Generated with [Claude Code](https://claude.ai/code)