### PR TITLE
Auth: Create auth context and hooks

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono, Spectral } from 'next/font/google';
 import './globals.css';
 import Header from '@/components/layout/Header';
+import { AuthProvider } from '@/lib/AuthContext';
 
 // Optimize font loading with subset and display swap
 const inter = Inter({
@@ -56,8 +57,10 @@ export default function RootLayout({
         />
       </head>
       <body className="font-serif antialiased">
-        <Header />
-        {children}
+        <AuthProvider>
+          <Header />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/hooks/__tests__/useAuth.test.ts
+++ b/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,132 @@
+import { renderHook } from '@testing-library/react';
+import { useAuth } from '../useAuth';
+import { AuthProvider } from '@/lib/AuthContext';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { createClient } from '@/lib/supabase/client';
+import type { User, Session } from '@supabase/supabase-js';
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+describe('useAuth', () => {
+  const mockUser: User = {
+    id: 'test-user-id',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2024-01-01',
+  };
+
+  const mockSession: Session = {
+    access_token: 'test-token',
+    token_type: 'bearer',
+    expires_in: 3600,
+    expires_at: 1234567890,
+    refresh_token: 'test-refresh-token',
+    user: mockUser,
+  };
+
+  let mockSupabaseClient: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockSupabaseClient = {
+      auth: {
+        getSession: vi
+          .fn()
+          .mockResolvedValue({ data: { session: null }, error: null }),
+        onAuthStateChange: vi.fn().mockReturnValue({
+          data: {
+            subscription: {
+              unsubscribe: vi.fn(),
+            },
+          },
+        }),
+        signInWithPassword: vi.fn(),
+        signUp: vi.fn(),
+        signOut: vi.fn().mockResolvedValue({ error: null }),
+        resetPasswordForEmail: vi.fn(),
+        updateUser: vi.fn(),
+      },
+    };
+
+    vi.mocked(createClient).mockReturnValue(mockSupabaseClient);
+  });
+
+  it('provides all auth methods and state', async () => {
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current).toHaveProperty('user');
+    expect(result.current).toHaveProperty('session');
+    expect(result.current).toHaveProperty('loading');
+    expect(result.current).toHaveProperty('error');
+    expect(result.current).toHaveProperty('isAuthenticated');
+    expect(result.current).toHaveProperty('signIn');
+    expect(result.current).toHaveProperty('signUp');
+    expect(result.current).toHaveProperty('signOut');
+    expect(result.current).toHaveProperty('resetPassword');
+    expect(result.current).toHaveProperty('updatePassword');
+  });
+
+  it('reflects authentication state correctly', async () => {
+    // Start with no session
+    const { result, rerender } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBe(null);
+
+    // Simulate auth state change to signed in
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+
+    const authChangeCallback =
+      mockSupabaseClient.auth.onAuthStateChange.mock.calls[0][0];
+    authChangeCallback('SIGNED_IN', mockSession);
+
+    rerender();
+
+    // Wait for state update
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it('handles loading state', () => {
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    // Initially loading should be true
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('provides working auth methods', async () => {
+    mockSupabaseClient.auth.signInWithPassword.mockResolvedValue({
+      data: { user: mockUser, session: mockSession },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    // Test signIn method
+    await result.current.signIn('test@example.com', 'password');
+    expect(mockSupabaseClient.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: 'test@example.com',
+      password: 'password',
+    });
+
+    // Test signOut method
+    await result.current.signOut();
+    expect(mockSupabaseClient.auth.signOut).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useRequireAuth.test.ts
+++ b/src/hooks/__tests__/useRequireAuth.test.ts
@@ -1,0 +1,151 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useRequireAuth } from '../useRequireAuth';
+import { AuthProvider } from '@/lib/AuthContext';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { createClient } from '@/lib/supabase/client';
+import type { User, Session } from '@supabase/supabase-js';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+describe('useRequireAuth', () => {
+  const mockUser: User = {
+    id: 'test-user-id',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2024-01-01',
+  };
+
+  const mockSession: Session = {
+    access_token: 'test-token',
+    token_type: 'bearer',
+    expires_in: 3600,
+    expires_at: 1234567890,
+    refresh_token: 'test-refresh-token',
+    user: mockUser,
+  };
+
+  let mockSupabaseClient: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSupabaseClient = {
+      auth: {
+        getSession: vi
+          .fn()
+          .mockResolvedValue({ data: { session: null }, error: null }),
+        onAuthStateChange: vi.fn().mockReturnValue({
+          data: {
+            subscription: {
+              unsubscribe: vi.fn(),
+            },
+          },
+        }),
+      },
+    };
+
+    vi.mocked(createClient).mockReturnValue(mockSupabaseClient);
+  });
+
+  it('redirects to signin when not authenticated', async () => {
+    const { result } = renderHook(() => useRequireAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/signin');
+  });
+
+  it('redirects to custom path when specified', async () => {
+    const { result } = renderHook(
+      () => useRequireAuth({ redirectTo: '/custom-login' }),
+      {
+        wrapper: AuthProvider,
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith('/custom-login');
+  });
+
+  it('does not redirect when authenticated', async () => {
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useRequireAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(mockUser);
+  });
+
+  it('does not redirect while loading', () => {
+    const { result } = renderHook(() => useRequireAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    expect(result.current.loading).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('calls custom callback instead of redirecting', async () => {
+    const onUnauthenticated = vi.fn();
+
+    const { result } = renderHook(() => useRequireAuth({ onUnauthenticated }), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(onUnauthenticated).toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it('returns correct auth state', async () => {
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    });
+
+    const { result } = renderHook(() => useRequireAuth(), {
+      wrapper: AuthProvider,
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      user: mockUser,
+      loading: false,
+      isAuthenticated: true,
+    });
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,4 @@
 // Custom hooks will be exported from here
-export {};
+export { useAuth } from './useAuth';
+export { useRequireAuth } from './useRequireAuth';
+export { useUser } from './useUser';

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { useAuthContext } from '@/lib/AuthContext';
+
+export function useAuth() {
+  const context = useAuthContext();
+
+  return {
+    user: context.user,
+    session: context.session,
+    loading: context.loading,
+    error: context.error,
+    isAuthenticated: !!context.user,
+    signIn: context.signIn,
+    signUp: context.signUp,
+    signOut: context.signOut,
+    resetPassword: context.resetPassword,
+    updatePassword: context.updatePassword,
+  };
+}

--- a/src/hooks/useRequireAuth.ts
+++ b/src/hooks/useRequireAuth.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from './useAuth';
+
+interface UseRequireAuthOptions {
+  redirectTo?: string;
+  onUnauthenticated?: () => void;
+}
+
+export function useRequireAuth(options: UseRequireAuthOptions = {}) {
+  const { user, loading, isAuthenticated } = useAuth();
+  const router = useRouter();
+  const { redirectTo = '/signin', onUnauthenticated } = options;
+
+  useEffect(() => {
+    if (!loading && !isAuthenticated) {
+      if (onUnauthenticated) {
+        onUnauthenticated();
+      } else {
+        router.push(redirectTo);
+      }
+    }
+  }, [loading, isAuthenticated, router, redirectTo, onUnauthenticated]);
+
+  return {
+    user,
+    loading,
+    isAuthenticated,
+  };
+}

--- a/src/lib/AuthContext.tsx
+++ b/src/lib/AuthContext.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { User, Session } from '@supabase/supabase-js';
+import { createClient } from '@/lib/supabase/client';
+
+interface AuthState {
+  user: User | null;
+  session: Session | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+interface AuthContextValue extends AuthState {
+  signIn: (email: string, password: string) => Promise<void>;
+  signUp: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+  resetPassword: (email: string) => Promise<void>;
+  updatePassword: (newPassword: string) => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [authState, setAuthState] = useState<AuthState>({
+    user: null,
+    session: null,
+    loading: true,
+    error: null,
+  });
+
+  const supabase = createClient();
+
+  useEffect(() => {
+    // Get initial session
+    const initializeAuth = async () => {
+      try {
+        const {
+          data: { session },
+          error,
+        } = await supabase.auth.getSession();
+        if (error) throw error;
+
+        setAuthState({
+          user: session?.user ?? null,
+          session,
+          loading: false,
+          error: null,
+        });
+      } catch (error) {
+        setAuthState({
+          user: null,
+          session: null,
+          loading: false,
+          error: error as Error,
+        });
+      }
+    };
+
+    initializeAuth();
+
+    // Listen for auth state changes
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange(async (event, session) => {
+      setAuthState((prevState) => ({
+        ...prevState,
+        user: session?.user ?? null,
+        session,
+        loading: false,
+        error: null,
+      }));
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [supabase.auth]);
+
+  const signIn = async (email: string, password: string) => {
+    try {
+      setAuthState((prev) => ({ ...prev, loading: true, error: null }));
+      const { error } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+      if (error) throw error;
+    } catch (error) {
+      setAuthState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error as Error,
+      }));
+      throw error;
+    }
+  };
+
+  const signUp = async (email: string, password: string) => {
+    try {
+      setAuthState((prev) => ({ ...prev, loading: true, error: null }));
+      const { error } = await supabase.auth.signUp({
+        email,
+        password,
+      });
+      if (error) throw error;
+    } catch (error) {
+      setAuthState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error as Error,
+      }));
+      throw error;
+    }
+  };
+
+  const signOut = async () => {
+    try {
+      setAuthState((prev) => ({ ...prev, loading: true, error: null }));
+      const { error } = await supabase.auth.signOut();
+      if (error) throw error;
+    } catch (error) {
+      setAuthState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error as Error,
+      }));
+      throw error;
+    }
+  };
+
+  const resetPassword = async (email: string) => {
+    try {
+      setAuthState((prev) => ({ ...prev, loading: true, error: null }));
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/auth/reset-password`,
+      });
+      if (error) throw error;
+    } catch (error) {
+      setAuthState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error as Error,
+      }));
+      throw error;
+    }
+  };
+
+  const updatePassword = async (newPassword: string) => {
+    try {
+      setAuthState((prev) => ({ ...prev, loading: true, error: null }));
+      const { error } = await supabase.auth.updateUser({
+        password: newPassword,
+      });
+      if (error) throw error;
+    } catch (error) {
+      setAuthState((prev) => ({
+        ...prev,
+        loading: false,
+        error: error as Error,
+      }));
+      throw error;
+    }
+  };
+
+  const value: AuthContextValue = {
+    ...authState,
+    signIn,
+    signUp,
+    signOut,
+    resetPassword,
+    updatePassword,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthContext() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/lib/__tests__/AuthContext.test.tsx
+++ b/src/lib/__tests__/AuthContext.test.tsx
@@ -1,0 +1,288 @@
+import React from 'react';
+import { render, screen, waitFor, renderHook } from '@testing-library/react';
+import { AuthProvider, useAuthContext } from '../AuthContext';
+import { createClient } from '@/lib/supabase/client';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { User, Session } from '@supabase/supabase-js';
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: vi.fn(),
+}));
+
+describe('AuthContext', () => {
+  const mockUser: User = {
+    id: 'test-user-id',
+    email: 'test@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2024-01-01',
+  };
+
+  const mockSession: Session = {
+    access_token: 'test-token',
+    token_type: 'bearer',
+    expires_in: 3600,
+    expires_at: 1234567890,
+    refresh_token: 'test-refresh-token',
+    user: mockUser,
+  };
+
+  let mockSupabaseClient: ReturnType<typeof vi.fn>;
+  let mockAuthStateSubscription: { unsubscribe: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockAuthStateSubscription = {
+      unsubscribe: vi.fn(),
+    };
+
+    mockSupabaseClient = {
+      auth: {
+        getSession: vi
+          .fn()
+          .mockResolvedValue({ data: { session: null }, error: null }),
+        onAuthStateChange: vi.fn().mockReturnValue({
+          data: { subscription: mockAuthStateSubscription },
+        }),
+        signInWithPassword: vi.fn(),
+        signUp: vi.fn(),
+        signOut: vi.fn(),
+        resetPasswordForEmail: vi.fn(),
+        updateUser: vi.fn(),
+      },
+    };
+
+    vi.mocked(createClient).mockReturnValue(mockSupabaseClient);
+  });
+
+  describe('AuthProvider', () => {
+    it('provides initial auth state', async () => {
+      const TestComponent = () => {
+        const auth = useAuthContext();
+        return (
+          <div>
+            <div data-testid="loading">{auth.loading.toString()}</div>
+            <div data-testid="user">{auth.user?.email || 'null'}</div>
+          </div>
+        );
+      };
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      expect(screen.getByTestId('loading')).toHaveTextContent('true');
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('false');
+      });
+
+      expect(screen.getByTestId('user')).toHaveTextContent('null');
+    });
+
+    it('initializes with existing session', async () => {
+      mockSupabaseClient.auth.getSession.mockResolvedValue({
+        data: { session: mockSession },
+        error: null,
+      });
+
+      const TestComponent = () => {
+        const auth = useAuthContext();
+        return <div data-testid="user">{auth.user?.email || 'null'}</div>;
+      };
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('user')).toHaveTextContent(
+          'test@example.com'
+        );
+      });
+    });
+
+    it('handles auth state changes', async () => {
+      const TestComponent = () => {
+        const auth = useAuthContext();
+        return <div data-testid="user">{auth.user?.email || 'null'}</div>;
+      };
+
+      render(
+        <AuthProvider>
+          <TestComponent />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('user')).toHaveTextContent('null');
+      });
+
+      // Simulate auth state change
+      const authChangeCallback =
+        mockSupabaseClient.auth.onAuthStateChange.mock.calls[0][0];
+      authChangeCallback('SIGNED_IN', mockSession);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('user')).toHaveTextContent(
+          'test@example.com'
+        );
+      });
+    });
+
+    it('unsubscribes from auth state changes on unmount', () => {
+      const { unmount } = render(
+        <AuthProvider>
+          <div>Test</div>
+        </AuthProvider>
+      );
+
+      unmount();
+
+      expect(mockAuthStateSubscription.unsubscribe).toHaveBeenCalled();
+    });
+  });
+
+  describe('Auth methods', () => {
+    it('handles sign in', async () => {
+      mockSupabaseClient.auth.signInWithPassword.mockResolvedValue({
+        data: { user: mockUser, session: mockSession },
+        error: null,
+      });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await result.current.signIn('test@example.com', 'password');
+
+      expect(mockSupabaseClient.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password',
+      });
+    });
+
+    it('handles sign in errors', async () => {
+      const error = new Error('Invalid credentials');
+      mockSupabaseClient.auth.signInWithPassword.mockResolvedValue({
+        data: { user: null, session: null },
+        error,
+      });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await expect(
+        result.current.signIn('test@example.com', 'wrong-password')
+      ).rejects.toThrow('Invalid credentials');
+    });
+
+    it('handles sign up', async () => {
+      mockSupabaseClient.auth.signUp.mockResolvedValue({
+        data: { user: mockUser, session: mockSession },
+        error: null,
+      });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await result.current.signUp('test@example.com', 'password');
+
+      expect(mockSupabaseClient.auth.signUp).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password',
+      });
+    });
+
+    it('handles sign out', async () => {
+      mockSupabaseClient.auth.signOut.mockResolvedValue({ error: null });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await result.current.signOut();
+
+      expect(mockSupabaseClient.auth.signOut).toHaveBeenCalled();
+    });
+
+    it('handles password reset', async () => {
+      mockSupabaseClient.auth.resetPasswordForEmail.mockResolvedValue({
+        error: null,
+      });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await result.current.resetPassword('test@example.com');
+
+      expect(
+        mockSupabaseClient.auth.resetPasswordForEmail
+      ).toHaveBeenCalledWith(
+        'test@example.com',
+        expect.objectContaining({
+          redirectTo: expect.stringContaining('/auth/reset-password'),
+        })
+      );
+    });
+
+    it('handles password update', async () => {
+      mockSupabaseClient.auth.updateUser.mockResolvedValue({ error: null });
+
+      const { result } = renderHook(() => useAuthContext(), {
+        wrapper: AuthProvider,
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      await result.current.updatePassword('new-password');
+
+      expect(mockSupabaseClient.auth.updateUser).toHaveBeenCalledWith({
+        password: 'new-password',
+      });
+    });
+  });
+
+  describe('useAuthContext', () => {
+    it('throws error when used outside AuthProvider', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useAuthContext());
+      }).toThrow('useAuthContext must be used within an AuthProvider');
+
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implemented AuthContext provider for centralized authentication state management
- Created useAuth hook for easy access to auth state and methods across the app
- Added useRequireAuth hook for route protection with customizable redirect behavior

## Changes
- **AuthContext.tsx**: Core authentication context with session management, auth state, and auth methods (sign in/up/out, password reset)
- **useAuth hook**: Simplified interface to access auth context with isAuthenticated helper
- **useRequireAuth hook**: Route protection hook with automatic redirect for unauthenticated users
- **Integration**: AuthProvider wrapped around app layout for global auth state
- **Tests**: Comprehensive test coverage for all auth functionality

## Test plan
- [x] Auth context properly initializes and manages session state
- [x] useAuth hook provides all authentication methods and state
- [x] useRequireAuth redirects unauthenticated users
- [x] Session persistence across page reloads
- [x] All tests pass with proper mocking

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)