### PR TITLE
feat: implement protected route middleware for authentication

### DIFF
--- a/src/app/(protected)/layout.tsx
+++ b/src/app/(protected)/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export default function ProtectedLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(protected)/loading.tsx
+++ b/src/app/(protected)/loading.tsx
@@ -1,0 +1,12 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <div className="text-center">
+        <h2 className="text-lg font-medium text-gray-900">Loading...</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Checking authentication status
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(protected)/write/page.tsx
+++ b/src/app/(protected)/write/page.tsx
@@ -1,0 +1,11 @@
+export default function WritePage() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold text-gray-900 mb-4">Write</h1>
+      <p className="text-gray-600">
+        This is a protected page. You can only access this if you are
+        authenticated.
+      </p>
+    </div>
+  );
+}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { createClient } from '@/lib/supabase/client';
+import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -22,6 +22,7 @@ export default function SignInForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const redirect = searchParams.get('redirect') || '/';
+  const { signIn } = useAuth();
 
   const {
     register,
@@ -36,11 +37,7 @@ export default function SignInForm() {
     setIsLoading(true);
 
     try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithPassword({
-        email: data.email,
-        password: data.password,
-      });
+      const { error } = await signIn(data.email, data.password);
 
       if (error) {
         setError('root', {
@@ -51,10 +48,13 @@ export default function SignInForm() {
         router.push(redirect);
         router.refresh();
       }
-    } catch {
+    } catch (error) {
       setError('root', {
         type: 'manual',
-        message: 'An unexpected error occurred. Please try again.',
+        message:
+          error instanceof Error
+            ? error.message
+            : 'An unexpected error occurred. Please try again.',
       });
     } finally {
       setIsLoading(false);

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -37,17 +37,9 @@ export default function SignInForm() {
     setIsLoading(true);
 
     try {
-      const { error } = await signIn(data.email, data.password);
-
-      if (error) {
-        setError('root', {
-          type: 'manual',
-          message: error.message,
-        });
-      } else {
-        router.push(redirect);
-        router.refresh();
-      }
+      await signIn(data.email, data.password);
+      router.push(redirect);
+      router.refresh();
     } catch (error) {
       setError('root', {
         type: 'manual',

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -7,7 +7,7 @@ import { z } from 'zod';
 import { createClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 
 const signInSchema = z.object({
@@ -20,6 +20,8 @@ type SignInFormData = z.infer<typeof signInSchema>;
 export default function SignInForm() {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const redirect = searchParams.get('redirect') || '/';
 
   const {
     register,
@@ -46,7 +48,7 @@ export default function SignInForm() {
           message: error.message,
         });
       } else {
-        router.push('/');
+        router.push(redirect);
         router.refresh();
       }
     } catch {

--- a/src/components/auth/SignOutButton.tsx
+++ b/src/components/auth/SignOutButton.tsx
@@ -10,38 +10,26 @@ export default function SignOutButton() {
   const router = useRouter();
 
   const handleSignOut = async () => {
-    console.log('Sign out button clicked');
     if (isLoading) {
-      console.log('Already loading, preventing multiple clicks');
       return;
     }
 
     setIsLoading(true);
-    console.log('Starting sign out process...');
 
     try {
       const supabase = createClient();
-      console.log('Supabase client created');
-
       const { error } = await supabase.auth.signOut();
-      console.log('Sign out response:', { error });
 
       if (error) {
         console.error('Error signing out:', error);
-      } else {
-        console.log('Sign out successful, redirecting...');
       }
 
       // Always redirect and refresh to update server components
-      console.log('Pushing to home page...');
       router.push('/');
-      console.log('Refreshing router...');
       router.refresh(); // This is crucial for updating server-rendered auth state
-      console.log('Router refresh complete');
     } catch (error) {
       console.error('Caught error during sign out:', error);
     } finally {
-      console.log('Setting loading to false');
       setIsLoading(false);
     }
   };
@@ -49,7 +37,6 @@ export default function SignOutButton() {
   return (
     <Button
       onClick={(e) => {
-        console.log('Button onClick triggered');
         e.preventDefault(); // Prevent any form submission if in a form
         handleSignOut();
       }}

--- a/src/hooks/useRequireAuth.ts
+++ b/src/hooks/useRequireAuth.ts
@@ -12,7 +12,7 @@ interface UseRequireAuthOptions {
 export function useRequireAuth(options: UseRequireAuthOptions = {}) {
   const { user, loading, isAuthenticated } = useAuth();
   const router = useRouter();
-  const { redirectTo = '/signin', onUnauthenticated } = options;
+  const { redirectTo = '/auth/sign-in', onUnauthenticated } = options;
 
   useEffect(() => {
     if (!loading && !isAuthenticated) {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Mock @supabase/ssr before importing middleware
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: vi.fn(),
+}));
+
+// Mock next/server to handle the request object properly
+vi.mock('next/server', async () => {
+  const actual =
+    await vi.importActual<typeof import('next/server')>('next/server');
+  return {
+    ...actual,
+    NextResponse: {
+      ...actual.NextResponse,
+      next: vi.fn((_init?: ResponseInit) => {
+        const response = new actual.NextResponse(null, { status: 200 });
+        // Mock cookies methods
+        response.cookies.set = vi.fn();
+        response.cookies.getAll = vi.fn(() => []);
+        return response;
+      }),
+      redirect: vi.fn((url: string | URL) => {
+        const response = new actual.NextResponse(null, { status: 307 });
+        response.headers.set('location', url.toString());
+        return response;
+      }),
+    },
+  };
+});
+
+import { middleware, config } from './middleware';
+
+// Helper function to create a mock NextRequest
+function createMockRequest(
+  url: string,
+  options?: {
+    cookies?: Record<string, string>;
+    headers?: Record<string, string>;
+  }
+) {
+  // Create proper headers instance
+  const headers = new Headers(options?.headers);
+
+  const request = new NextRequest(new URL(url, 'http://localhost:3000'), {
+    headers,
+  });
+
+  // Mock cookies if needed
+  if (options?.cookies) {
+    const cookieStore = new Map<string, string>();
+    Object.entries(options.cookies).forEach(([name, value]) => {
+      cookieStore.set(name, value);
+    });
+
+    // Override cookie methods
+    Object.defineProperty(request, 'cookies', {
+      value: {
+        get: (name: string) => ({ value: cookieStore.get(name), name }),
+        getAll: () =>
+          Array.from(cookieStore.entries()).map(([name, value]) => ({
+            name,
+            value,
+          })),
+        set: (name: string, value: string) => cookieStore.set(name, value),
+        delete: (name: string) => cookieStore.delete(name),
+        has: (name: string) => cookieStore.has(name),
+      },
+      writable: false,
+      configurable: true,
+    });
+  }
+
+  return request;
+}
+
+describe('Middleware', () => {
+  const originalEnv = process.env;
+  let mockGetUser: ReturnType<typeof vi.fn>;
+  let mockCreateServerClient: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: 'test-anon-key',
+    };
+
+    // Reset mocks
+    vi.clearAllMocks();
+
+    // Get the mocked createServerClient
+    const { createServerClient } = await import('@supabase/ssr');
+    mockCreateServerClient = vi.mocked(createServerClient);
+
+    // Setup mock for createServerClient
+    mockGetUser = vi.fn();
+    mockCreateServerClient.mockReturnValue({
+      auth: {
+        getUser: mockGetUser,
+      },
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('Environment Variables', () => {
+    it('should handle missing SUPABASE_URL', async () => {
+      delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const request = createMockRequest('/');
+      const response = await middleware(request);
+
+      expect(response).toBeDefined();
+      expect(response.status).toBe(200);
+    });
+
+    it('should handle missing SUPABASE_ANON_KEY', async () => {
+      delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      const request = createMockRequest('/');
+      const response = await middleware(request);
+
+      expect(response).toBeDefined();
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe('Protected Routes', () => {
+    const protectedRoutes = ['/write', '/profile', '/dashboard', '/settings'];
+
+    protectedRoutes.forEach((route) => {
+      it(`should redirect to sign-in for ${route} when not authenticated`, async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response).toBeDefined();
+        expect(response.status).toBe(307); // Redirect status
+        expect(response.headers.get('location')).toBe(
+          `http://localhost:3000/auth/sign-in?redirect=${encodeURIComponent(route)}`
+        );
+      });
+
+      it(`should allow access to ${route} when authenticated`, async () => {
+        mockGetUser.mockResolvedValue({
+          data: { user: { id: 'user-123', email: 'test@example.com' } },
+          error: null,
+        });
+
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response).toBeDefined();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('location')).toBeNull();
+      });
+    });
+
+    it('should preserve the path but not query parameters when redirecting to sign-in', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      const request = createMockRequest('/profile?tab=settings');
+      const response = await middleware(request);
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get('location');
+      expect(location).toContain('/auth/sign-in');
+      expect(location).toContain('redirect=%2Fprofile');
+      // The middleware preserves the pathname but not the query params in the redirect param
+    });
+  });
+
+  describe('Auth Routes', () => {
+    const authRoutes = ['/auth/sign-in', '/auth/sign-up'];
+
+    authRoutes.forEach((route) => {
+      it(`should redirect to home from ${route} when authenticated`, async () => {
+        mockGetUser.mockResolvedValue({
+          data: { user: { id: 'user-123', email: 'test@example.com' } },
+          error: null,
+        });
+
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response).toBeDefined();
+        expect(response.status).toBe(307);
+        expect(response.headers.get('location')).toBe('http://localhost:3000/');
+      });
+
+      it(`should allow access to ${route} when not authenticated`, async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response).toBeDefined();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('location')).toBeNull();
+      });
+    });
+  });
+
+  describe('Public Routes', () => {
+    const publicRoutes = ['/', '/about', '/blog', '/contact'];
+
+    publicRoutes.forEach((route) => {
+      it(`should allow access to ${route} when not authenticated`, async () => {
+        mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response).toBeDefined();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('location')).toBeNull();
+      });
+
+      it(`should allow access to ${route} when authenticated`, async () => {
+        mockGetUser.mockResolvedValue({
+          data: { user: { id: 'user-123', email: 'test@example.com' } },
+          error: null,
+        });
+
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response).toBeDefined();
+        expect(response.status).toBe(200);
+        expect(response.headers.get('location')).toBeNull();
+      });
+    });
+  });
+
+  describe('Cookie Handling', () => {
+    it('should preserve cookies through the middleware', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      const request = createMockRequest('/', {
+        cookies: {
+          'test-cookie': 'test-value',
+          'another-cookie': 'another-value',
+        },
+      });
+
+      const response = await middleware(request);
+
+      expect(response).toBeDefined();
+      // Verify that the Supabase client received the cookies
+      expect(mockCreateServerClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-anon-key',
+        expect.objectContaining({
+          cookies: expect.objectContaining({
+            getAll: expect.any(Function),
+            setAll: expect.any(Function),
+          }),
+        })
+      );
+    });
+
+    it('should handle cookie updates from Supabase', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      const request = createMockRequest('/');
+      const response = await middleware(request);
+
+      // Verify response is returned correctly
+      expect(response).toBeDefined();
+
+      // Test that setAll function works correctly
+      const cookieOptions = mockCreateServerClient.mock.calls[0][2];
+
+      // Simulate Supabase setting cookies
+      const cookiesToSet = [
+        {
+          name: 'sb-access-token',
+          value: 'token123',
+          options: { httpOnly: true },
+        },
+        {
+          name: 'sb-refresh-token',
+          value: 'refresh123',
+          options: { httpOnly: true },
+        },
+      ];
+
+      cookieOptions.cookies.setAll(cookiesToSet);
+
+      // Verify cookies were set on the request
+      expect(request.cookies.get('sb-access-token')?.value).toBe('token123');
+      expect(request.cookies.get('sb-refresh-token')?.value).toBe('refresh123');
+    });
+  });
+
+  describe('Config Matcher', () => {
+    it('should have correct matcher configuration', () => {
+      expect(config.matcher).toEqual([
+        '/write',
+        '/profile/:path*',
+        '/dashboard/:path*',
+        '/settings/:path*',
+        '/auth/:path*',
+      ]);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle auth.getUser errors gracefully', async () => {
+      mockGetUser.mockResolvedValue({
+        data: { user: null },
+        error: new Error('Auth error'),
+      });
+
+      const request = createMockRequest('/profile');
+      const response = await middleware(request);
+
+      // Should redirect to sign-in when user is null (regardless of error)
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toContain('/auth/sign-in');
+    });
+
+    it('should handle Supabase client creation errors', async () => {
+      mockCreateServerClient.mockImplementation(() => {
+        throw new Error('Client creation failed');
+      });
+
+      const request = createMockRequest('/');
+
+      // Should throw the error since it's not caught in the middleware
+      await expect(middleware(request)).rejects.toThrow(
+        'Client creation failed'
+      );
+    });
+  });
+
+  describe('Nested Protected Routes', () => {
+    it('should protect nested routes under protected paths', async () => {
+      mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+      const nestedRoutes = [
+        '/profile/edit',
+        '/dashboard/analytics',
+        '/settings/security',
+      ];
+
+      for (const route of nestedRoutes) {
+        const request = createMockRequest(route);
+        const response = await middleware(request);
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get('location')).toContain('/auth/sign-in');
+      }
+    });
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -42,7 +42,7 @@ export async function middleware(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   // Define protected routes
-  const protectedRoutes = ['/dashboard', '/profile', '/settings'];
+  const protectedRoutes = ['/write', '/profile', '/dashboard', '/settings'];
   const authRoutes = ['/auth/sign-in', '/auth/sign-up'];
 
   const isProtectedRoute = protectedRoutes.some((route) =>
@@ -56,6 +56,8 @@ export async function middleware(request: NextRequest) {
   if (!user && isProtectedRoute) {
     const url = request.nextUrl.clone();
     url.pathname = '/auth/sign-in';
+    // Preserve the intended destination for redirect after login
+    url.searchParams.set('redirect', request.nextUrl.pathname);
     return NextResponse.redirect(url);
   }
 
@@ -84,14 +86,10 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    /*
-     * Match all request paths except:
-     * - _next/static (static files)
-     * - _next/image (image optimization files)
-     * - favicon.ico (favicon file)
-     * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
-     * Feel free to modify this pattern to include more paths.
-     */
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+    '/write',
+    '/profile/:path*',
+    '/dashboard/:path*',
+    '/settings/:path*',
+    '/auth/:path*',
   ],
 };


### PR DESCRIPTION
## Summary
- Implemented authentication middleware to protect routes requiring user login
- Added redirect parameter to preserve intended destination after authentication
- Created loading UI for auth state checks
- Fixed all code review issues

## Changes Made
- Updated `middleware.ts` to:
  - Add `/write` to protected routes list
  - Preserve intended destination with redirect query parameter
  - Configure specific route matcher for better performance
- Updated `SignInForm` to:
  - Handle redirect parameter after successful login
  - Use auth context instead of direct Supabase client
- Created loading UI component for auth checks during route navigation
- Added comprehensive test coverage with 29 passing tests
- Fixed all linting issues and console.log statements
- Updated tests to work with auth context implementation

## Code Review Fixes
✅ Removed all console.log statements from SignOutButton.tsx
✅ Fixed redirect path inconsistency in useRequireAuth hook (/signin → /auth/sign-in)
✅ Updated SignInForm to use auth context instead of direct Supabase client
✅ Fixed SignInForm tests to work with the new auth implementation
✅ All Vercel deployment checks passing

## Test Plan
✅ Middleware redirects unauthenticated users to sign-in page
✅ Redirect parameter preserves original destination
✅ Authenticated users can access protected routes
✅ Public routes remain accessible without authentication
✅ Auth routes redirect authenticated users to home
✅ All tests pass (middleware tests: 29/29, SignInForm tests: 10/10)
✅ No linting errors or warnings
✅ Vercel deployment successful

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)