### PR TITLE
feat: replace editor preview with custom PreviewPane

### DIFF
--- a/src/app/(protected)/write/__tests__/page.test.tsx
+++ b/src/app/(protected)/write/__tests__/page.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@/components/MarkdownEditor', () => ({
           onChange={(e) => setContent(e.target.value)}
           data-testid="markdown-editor"
         />
-        <button onClick={() => onSave(content)}>Save</button>
+        <button onClick={() => onSave(content)}>Post</button>
       </div>
     );
   },
@@ -67,7 +67,7 @@ describe('WritePage', () => {
     } as any);
   });
 
-  it('should create a new post as published and redirect to homepage on save', async () => {
+  it('should create a new post as published and reset form on save', async () => {
     const mockPost = { id: '123', title: 'Test Post' };
     vi.mocked(createPost).mockResolvedValue(mockPost as any);
 
@@ -78,7 +78,7 @@ describe('WritePage', () => {
     fireEvent.change(titleInput, { target: { value: 'Test Post' } });
 
     // Click save
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByText('Post');
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -87,7 +87,18 @@ describe('WritePage', () => {
         content: 'Test content',
         status: 'published',
       });
-      expect(mockPush).toHaveBeenCalledWith('/');
+      // Should not redirect anymore
+      expect(mockPush).not.toHaveBeenCalled();
+      // Check that form is reset
+      expect(screen.getByPlaceholderText('Enter your title...')).toHaveValue(
+        ''
+      );
+      // Check success message
+      expect(
+        screen.getByText(
+          'Post published successfully! You can create another post.'
+        )
+      ).toBeInTheDocument();
     });
   });
 
@@ -115,7 +126,7 @@ describe('WritePage', () => {
     fireEvent.change(titleInput, { target: { value: 'Updated Post' } });
 
     // Click save
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByText('Post');
     fireEvent.click(saveButton);
 
     await waitFor(() => {
@@ -132,7 +143,7 @@ describe('WritePage', () => {
     render(<WritePage />);
 
     // Click save without entering title
-    const saveButton = screen.getByText('Save');
+    const saveButton = screen.getByText('Post');
     fireEvent.click(saveButton);
 
     await waitFor(() => {

--- a/src/app/(protected)/write/page.tsx
+++ b/src/app/(protected)/write/page.tsx
@@ -14,6 +14,7 @@ export default function WritePage() {
   const [content, setContent] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [currentPostId, setCurrentPostId] = useState<string | null>(postId);
 
   // Load existing post if editing
@@ -48,6 +49,7 @@ export default function WritePage() {
     }
 
     setError(null);
+    setSuccess(null);
 
     try {
       if (currentPostId) {
@@ -68,8 +70,20 @@ export default function WritePage() {
           status: 'published',
         });
 
-        // Redirect to homepage after successful save
-        router.push('/');
+        // Reset the form for a new post
+        setTitle('');
+        setContent('');
+        setCurrentPostId(null);
+
+        // Clear localStorage draft
+        localStorage.removeItem('draft-content');
+        localStorage.removeItem('draft-timestamp');
+
+        // Show success message
+        setSuccess('Post published successfully! You can create another post.');
+
+        // Clear success message after 5 seconds
+        setTimeout(() => setSuccess(null), 5000);
       }
     } catch (err) {
       console.error('Error saving post:', err);
@@ -116,6 +130,11 @@ export default function WritePage() {
           {error && (
             <div className="mb-2 p-2 bg-red-50 border border-red-200 text-red-700 rounded-md text-sm">
               {error}
+            </div>
+          )}
+          {success && (
+            <div className="mb-2 p-2 bg-green-50 border border-green-200 text-green-700 rounded-md text-sm">
+              {success}
             </div>
           )}
           <input


### PR DESCRIPTION
## Summary
- Replaces the built-in markdown preview with our custom PreviewPane component
- Changes the Save button to a Post button with better UX
- Implements form reset after successful post creation

## Changes Made

### 1. Editor Preview Replacement
- Removed the `preview="live"` mode from @uiw/react-md-editor
- Added toggle buttons to switch between Edit and Preview modes
- Integrated the custom PreviewPane component for preview functionality
- Maintained scroll synchronization support (foundation laid for future enhancement)

### 2. Save to Post Button
- Changed button text from "Save" to "Post"
- Updated icon from Save to Send for better visual clarity
- Updated button text states: "Posting..." while saving

### 3. Create Post Flow
- After successful post creation, the form now resets:
  - Title field is cleared
  - Content is cleared
  - LocalStorage draft is removed
- Shows a success message that auto-dismisses after 5 seconds
- User stays on the write page to create another post immediately
- Update posts still redirect to homepage (existing behavior maintained)

### 4. UI Improvements
- Added Edit/Preview toggle with icons (Edit3 and Eye from lucide-react)
- Toggle buttons have clear visual states
- Success messages styled with green background
- Error messages remain styled with red background

## Test Plan
- [x] Unit tests updated and passing
- [x] Build passes without errors
- [x] Lint checks pass
- [x] Manual testing of edit/preview toggle
- [x] Manual testing of post creation and form reset
- [x] Manual testing of post updates (should still redirect)

## Screenshots
The editor now has a toggle between Edit and Preview modes in the toolbar, and the Save button has been replaced with a Post button.

🤖 Generated with [Claude Code](https://claude.ai/code)