### PR TITLE
Fix profile link to use username instead of /profile

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,14 +2,19 @@
 
 import Link from 'next/link';
 import { useAuth } from '@/hooks/useAuth';
+import { useUserProfile } from '@/hooks/useUserProfile';
 import { Button } from '@/components/ui/Button';
 import { SignOutButton } from '@/components/auth';
 import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
 
 export default function Header() {
-  const { user, loading } = useAuth();
+  const { user, loading: authLoading } = useAuth();
+  const { profile, loading: profileLoading } = useUserProfile();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  const loading = authLoading || profileLoading;
+  const profileUrl = profile?.username ? `/${profile.username}` : '/profile';
 
   const toggleMobileMenu = () => {
     setIsMobileMenuOpen(!isMobileMenuOpen);
@@ -76,7 +81,7 @@ export default function Header() {
                         Dashboard
                       </Link>
                       <Link
-                        href="/profile"
+                        href={profileUrl}
                         className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                       >
                         Profile
@@ -170,7 +175,7 @@ export default function Header() {
                       Dashboard
                     </Link>
                     <Link
-                      href="/profile"
+                      href={profileUrl}
                       className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                       onClick={() => setIsMobileMenuOpen(false)}
                     >

--- a/src/hooks/__tests__/useUserProfile.test.tsx
+++ b/src/hooks/__tests__/useUserProfile.test.tsx
@@ -1,0 +1,107 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUserProfile } from '../useUserProfile';
+import { useAuth } from '../useAuth';
+import { getCurrentUserProfile } from '@/lib/supabase/profiles';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../useAuth');
+vi.mock('@/lib/supabase/profiles');
+
+describe('useUserProfile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return null profile when user is not authenticated', async () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: null,
+      loading: false,
+      session: null,
+      error: null,
+      isAuthenticated: false,
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      resetPassword: vi.fn(),
+      updatePassword: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(getCurrentUserProfile).not.toHaveBeenCalled();
+  });
+
+  it('should fetch profile when user is authenticated', async () => {
+    const mockUser = { id: '123', email: 'test@example.com' };
+    const mockProfile = {
+      id: '123',
+      username: 'testuser',
+      email: 'test@example.com',
+      full_name: 'Test User',
+      bio: null,
+      avatar_url: null,
+      created_at: '2023-01-01T00:00:00Z',
+      updated_at: '2023-01-01T00:00:00Z',
+    };
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser as unknown as ReturnType<typeof useAuth>['user'],
+      loading: false,
+      session: null,
+      error: null,
+      isAuthenticated: true,
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      resetPassword: vi.fn(),
+      updatePassword: vi.fn(),
+    });
+
+    vi.mocked(getCurrentUserProfile).mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.profile).toEqual(mockProfile);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(getCurrentUserProfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle profile fetch errors', async () => {
+    const mockUser = { id: '123', email: 'test@example.com' };
+    const mockError = new Error('Failed to fetch profile');
+
+    vi.mocked(useAuth).mockReturnValue({
+      user: mockUser as unknown as ReturnType<typeof useAuth>['user'],
+      loading: false,
+      session: null,
+      error: null,
+      isAuthenticated: true,
+      signIn: vi.fn(),
+      signUp: vi.fn(),
+      signOut: vi.fn(),
+      resetPassword: vi.fn(),
+      updatePassword: vi.fn(),
+    });
+
+    vi.mocked(getCurrentUserProfile).mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.error).toEqual(mockError);
+  });
+});

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useAuth } from './useAuth';
+import { getCurrentUserProfile } from '@/lib/supabase/profiles';
+import type { Database } from '@/types/database.generated';
+
+type Profile = Database['public']['Tables']['profiles']['Row'];
+
+export function useUserProfile() {
+  const { user, loading: authLoading } = useAuth();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    if (!user) {
+      setProfile(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchProfile() {
+      try {
+        setLoading(true);
+        const userProfile = await getCurrentUserProfile();
+        if (!cancelled) {
+          setProfile(userProfile);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err : new Error('Failed to fetch profile')
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchProfile();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  return {
+    profile,
+    loading: authLoading || loading,
+    error,
+    isAuthenticated: !!user,
+  };
+}


### PR DESCRIPTION
## Summary
- Fixed the bug where clicking the profile link in the user dropdown navigates to `/profile` (404 error) instead of `/<username>`
- Profile links now correctly navigate to the user's profile page at `/<username>`

## Changes Made
- Created `useUserProfile` hook to fetch the current user's profile data including username
- Updated `Header` component to dynamically generate profile URLs using the username from the profile data
- Added comprehensive tests for the new `useUserProfile` hook

## Test Plan
- [x] Verify that clicking the profile link in the desktop dropdown menu navigates to `/<username>`
- [x] Verify that clicking the profile link in the mobile menu navigates to `/<username>`
- [x] Verify fallback behavior when profile data is loading (temporarily shows `/profile`)
- [x] Run unit tests for the new hook

Closes #79

🤖 Generated with [Claude Code](https://claude.ai/code)