### PR TITLE
Remove Help Center link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -59,12 +59,6 @@ export default function Footer() {
                   About
                 </Link>
                 <Link
-                  href="/help"
-                  className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"
-                >
-                  Help Center
-                </Link>
-                <Link
                   href="/privacy"
                   className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"
                 >

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -21,9 +21,6 @@ describe('Footer', () => {
     // Resources links
     expect(screen.getByText('Resources')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'About' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: 'Help Center' })
-    ).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Privacy' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Terms' })).toBeInTheDocument();
 
@@ -62,10 +59,6 @@ describe('Footer', () => {
     expect(screen.getByRole('link', { name: 'About' })).toHaveAttribute(
       'href',
       '/about'
-    );
-    expect(screen.getByRole('link', { name: 'Help Center' })).toHaveAttribute(
-      'href',
-      '/help'
     );
     expect(screen.getByRole('link', { name: 'Privacy' })).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Summary
- remove Help Center from footer
- adjust footer tests

## Testing
- `npm run lint`
- `npm run format`
- `npm run test:run` *(fails: Missing Supabase env vars, unable to connect to DB, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6860c4d76a14832baac42e7bcbdb736d