### PR TITLE
Update footer link text to X.com

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -86,12 +86,12 @@ export default function Footer() {
               </h4>
               <nav className="flex flex-col space-y-1">
                 <a
-                  href="https://twitter.com"
+                  href="https://x.com/ccarella"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"
                 >
-                  Twitter
+                  X.com
                 </a>
                 <a
                   href="https://github.com"

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -29,7 +29,7 @@ describe('Footer', () => {
 
     // Connect links
     expect(screen.getByText('Connect')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Twitter' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'X.com' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'GitHub' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Contact' })).toBeInTheDocument();
   });
@@ -84,12 +84,12 @@ describe('Footer', () => {
   it('external links have proper attributes', () => {
     render(<Footer />);
 
-    const twitterLink = screen.getByRole('link', { name: 'Twitter' });
+    const xLink = screen.getByRole('link', { name: 'X.com' });
     const githubLink = screen.getByRole('link', { name: 'GitHub' });
 
     // Check external link attributes
-    expect(twitterLink).toHaveAttribute('target', '_blank');
-    expect(twitterLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(xLink).toHaveAttribute('target', '_blank');
+    expect(xLink).toHaveAttribute('rel', 'noopener noreferrer');
     expect(githubLink).toHaveAttribute('target', '_blank');
     expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
   });


### PR DESCRIPTION
## Summary
- update footer social link to X.com
- adjust Footer tests for new link text

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860c5d854f0832b8356072f6e57766d