### PR TITLE
Fix GitHub footer link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -94,7 +94,7 @@ export default function Footer() {
                   Twitter
                 </a>
                 <a
-                  href="https://github.com"
+                  href="https://github.com/ccarella/currents"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -90,8 +90,13 @@ describe('Footer', () => {
     // Check external link attributes
     expect(twitterLink).toHaveAttribute('target', '_blank');
     expect(twitterLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(twitterLink).toHaveAttribute('href', 'https://twitter.com');
     expect(githubLink).toHaveAttribute('target', '_blank');
     expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(githubLink).toHaveAttribute(
+      'href',
+      'https://github.com/ccarella/currents'
+    );
   });
 
   it('has proper semantic structure', () => {


### PR DESCRIPTION
## Summary
- link GitHub footer button to ccarella/currents repo
- check external hrefs in footer tests

## Testing
- `npm test` *(fails: Testing environment lacks dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6860c5a5285c832bb6448d49982f2f65