### PR TITLE
Remove Explore nav

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -26,12 +26,6 @@ export default function Footer() {
               </h4>
               <nav className="flex flex-col space-y-1">
                 <Link
-                  href="/explore"
-                  className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"
-                >
-                  Explore
-                </Link>
-                <Link
                   href="/write"
                   className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"
                 >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -51,12 +51,6 @@ export default function Header() {
               {/* Desktop Navigation */}
               <nav className="hidden md:flex items-center space-x-6">
                 <Link
-                  href="/explore"
-                  className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-                >
-                  Explore
-                </Link>
-                <Link
                   href="/about"
                   className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
                 >
@@ -122,13 +116,6 @@ export default function Header() {
         >
           <nav className="h-full overflow-y-auto safe-bottom">
             <div className="px-4 py-6 space-y-1">
-              <Link
-                href="/explore"
-                className="block px-4 py-3 rounded-lg text-lg font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 transition-colors touch-target"
-                onClick={() => setIsMobileMenuOpen(false)}
-              >
-                Explore
-              </Link>
               <Link
                 href="/about"
                 className="block px-4 py-3 rounded-lg text-lg font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800 transition-colors touch-target"

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -14,7 +14,6 @@ describe('Footer', () => {
 
     // Platform links
     expect(screen.getByText('Platform')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Explore' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Write' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
 
@@ -47,10 +46,6 @@ describe('Footer', () => {
     render(<Footer />);
 
     // Internal links
-    expect(screen.getByRole('link', { name: 'Explore' })).toHaveAttribute(
-      'href',
-      '/explore'
-    );
     expect(screen.getByRole('link', { name: 'Write' })).toHaveAttribute(
       'href',
       '/write'

--- a/src/components/layout/__tests__/Header.test.tsx
+++ b/src/components/layout/__tests__/Header.test.tsx
@@ -62,7 +62,6 @@ describe('Header Mobile Menu', () => {
 
     // Menu items should be visible
     expect(screen.getByRole('navigation')).toBeInTheDocument();
-    expect(screen.getByText('Explore')).toBeInTheDocument();
     expect(screen.getByText('About')).toBeInTheDocument();
   });
 
@@ -89,8 +88,8 @@ describe('Header Mobile Menu', () => {
     fireEvent.click(menuButton);
 
     // Click a navigation link
-    const exploreLink = screen.getByText('Explore');
-    fireEvent.click(exploreLink);
+    const aboutLink = screen.getByText('About');
+    fireEvent.click(aboutLink);
 
     // Menu should be hidden
     expect(screen.queryByRole('navigation')).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- remove Explore link from header and footer
- update tests accordingly

## Testing
- `npm test` *(fails: unable to run tests)*
- `npm run test:e2e` *(fails: supabase config missing)*
- `npm run lint`
- `npm run type-check` *(fails: types not generated)*

------
https://chatgpt.com/codex/tasks/task_b_6860c607bcec832ba45de6e653b6f934