### PR TITLE
Fix footer GitHub link

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -82,7 +82,7 @@ export default function Footer() {
                   X.com
                 </a>
                 <a
-                  href="https://github.com"
+                  href="https://github.com/ccarella/currents"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-sm text-gray-600 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white py-2 -ml-1 pl-1 rounded hover:bg-gray-50 dark:hover:bg-gray-900"

--- a/src/components/layout/__tests__/Footer.test.tsx
+++ b/src/components/layout/__tests__/Footer.test.tsx
@@ -67,6 +67,14 @@ describe('Footer', () => {
       'href',
       '/contact'
     );
+    expect(screen.getByRole('link', { name: 'X.com' })).toHaveAttribute(
+      'href',
+      'https://x.com/ccarella'
+    );
+    expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+      'href',
+      'https://github.com/ccarella/currents'
+    );
   });
 
   it('external links have proper attributes', () => {


### PR DESCRIPTION
## Summary
- update GitHub link in the footer
- check external link hrefs in footer tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860cd0c9f2c832b93ea4ea810beadf0